### PR TITLE
Add query scopes `whereApi` and `whereWeb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-route-statistics` will be documented in this file.
 
+## 1.1.0
+
+- Add query scopes `whereApi` and `whereWeb` to the `RouteStatistics` model.
+
 ## 1.0.0
 
 - First production ready release

--- a/src/Models/RouteStatistic.php
+++ b/src/Models/RouteStatistic.php
@@ -3,6 +3,7 @@
 namespace Bilfeldt\LaravelRouteStatistics\Models;
 
 use Bilfeldt\RequestLogger\Contracts\RequestLoggerInterface;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -34,6 +35,16 @@ class RouteStatistic extends Model implements RequestLoggerInterface
     //======================================================================
     // SCOPES
     //======================================================================
+
+    public function scopeWhereApi(Builder $query): Builder
+    {
+        return $query->where('route', 'LIKE', 'api.%');
+    }
+
+    public function scopeWhereWeb(Builder $query): Builder
+    {
+        return $query->where('route', 'NOT LIKE', 'api.%');
+    }
 
     //======================================================================
     // RELATIONS


### PR DESCRIPTION
- Add query scopes `whereApi` and `whereWeb` to the `RouteStatistics` model.