### PR TITLE
Update RouteStatisticFactory.php

### DIFF
--- a/database/factories/RouteStatisticFactory.php
+++ b/database/factories/RouteStatisticFactory.php
@@ -12,11 +12,12 @@ class RouteStatisticFactory extends Factory
     public function definition()
     {
         return [
-            'method' => $this->faker->randomElements(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
-            'route'  => $this->faker->domainWord().'.'.$this->faker->randomElements(['index', 'create', 'store', 'show', 'edit', 'update', 'destroy']),
-            'code'   => $this->faker->randomElement([200, 201, 202, 204, 300, 301, 302, 303, 304, 400, 401, 402, 403, 404, 405, 406, 422, 429, 500, 501, 502, 503, 504]),
-            'ip'     => $this->faker->ipv4,
-            'date'   => $this->faker->dateTime,
+            'method' => $this->faker->randomElement(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+            'route' => $this->faker->domainWord().'.'.$this->faker->randomElement(['index', 'create', 'store', 'show', 'edit', 'update', 'destroy']),
+            'status' => $this->faker->randomElement([200, 201, 202, 204, 300, 301, 302, 303, 304, 400, 401, 402, 403, 404, 405, 406, 422, 429, 500, 501, 502, 503, 504]),
+            'ip' => $this->faker->ipv4,
+            'date' => $this->faker->dateTime,
+            'counter' => $this->faker->randomNumber(4),
         ];
     }
 }

--- a/database/factories/RouteStatisticFactory.php
+++ b/database/factories/RouteStatisticFactory.php
@@ -15,8 +15,8 @@ class RouteStatisticFactory extends Factory
             'method' => $this->faker->randomElement(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
             'route' => $this->faker->domainWord().'.'.$this->faker->randomElement(['index', 'create', 'store', 'show', 'edit', 'update', 'destroy']),
             'status' => $this->faker->randomElement([200, 201, 202, 204, 300, 301, 302, 303, 304, 400, 401, 402, 403, 404, 405, 406, 422, 429, 500, 501, 502, 503, 504]),
-            'ip' => $this->faker->ipv4,
-            'date' => $this->faker->dateTime,
+            'ip' => $this->faker->ipv4(),
+            'date' => $this->faker->dateTime(),
             'counter' => $this->faker->randomNumber(4),
         ];
     }


### PR DESCRIPTION
This PR fixes 4 issues-

First,

```
// Before this PR:
// $this->faker->randomElements (plural)

// After this PR:
// $this->faker->randomElement (now singular)
```

Second,

```
// Before this PR:
// 'code'   =>

// After this PR:
// 'status'   => (replaced attribute name `code` with `status`)
```

Third,

```
// Before this PR:
// $this->faker->ipv4,
// $this->faker->dateTime,

// After this PR:
// $this->faker->ipv4(), (added parentheses)
// $this->faker->dateTime(), (added parentheses)
```

Fourth,

```
// Before this PR:
// had 5 attributes

// After this PR:
// 'counter'   => $this->faker->randomNumber(4), (added sixth attribute field)
```



