### PR TITLE
Allowing Laravel 10 with PHP 8.1 version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
+        php: [8.2, 8.1]
         laravel: [10.*]
         dependency-version: [prefer-stable]
         include:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Log Laravel requests and responses for statistical purposes and optionally aggre
 | Version | Laravel     | PHP                     |
 |---------|-------------|-------------------------|
 | 1.*     | 8.* \| 9.*  | 7.4.* \| 8.0.* \| 8.1.* |
-| 2.*     | 10.*        | 8.2.*                   |
+| 2.*     | 10.*        | 8.1.* \| 8.2.*          |
 
 ## Description
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0",
+        "php": "^8.1 || ^8.2",
         "bilfeldt/laravel-request-logger": "^2.0",
         "illuminate/contracts": "^10.0",
         "laravel/framework": "^10.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "~8.2.0",
+        "php": "~8.1.0",
         "bilfeldt/laravel-request-logger": "^2.0",
         "illuminate/contracts": "^10.0",
         "laravel/framework": "^10.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^8.1 || ^8.2",
+        "php": ~8.1.0 || ~8.2.0",
         "bilfeldt/laravel-request-logger": "^2.0",
         "illuminate/contracts": "^10.0",
         "laravel/framework": "^10.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "bilfeldt/laravel-request-logger": "^2.0",
         "illuminate/contracts": "^10.0",
         "laravel/framework": "^10.0"


### PR DESCRIPTION
# Description

This changes allow the usage of package using Laravel 10 with PHP 8.1

## Does this close any currently open issues?

The issue: [Not possible to use the package in Laravel 10 with PHP 8.1?](https://github.com/bilfeldt/laravel-route-statistics/issues/21)

Fixes #

Adding support for PHP 8.1 with Laravel 10.

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Any relevant logs, error output, etc?

Installing packages with my dev branch:
![image](https://github.com/bilfeldt/laravel-route-statistics/assets/60560085/6434634f-4029-412a-8e52-eff63c32b21d)


...
> Notice: The PR [Allowing Laravel 10 with PHP 8.1](https://github.com/bilfeldt/laravel-request-logger/pull/22) at [[laravel-request-logger](https://github.com/bilfeldt/laravel-request-logger)](https://github.com/bilfeldt/laravel-request-logger) package must be accepted and released before of this.

# Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
