### PR TITLE
[v3.x] Add created at column to route statistics model to have laravel nova not throwing an exception

### DIFF
--- a/src/Models/RouteStatistic.php
+++ b/src/Models/RouteStatistic.php
@@ -21,6 +21,9 @@ class RouteStatistic extends Model implements RequestLoggerInterface
 
     public $timestamps = false;
 
+    const CREATED_AT = 'date';
+    const UPDATED_AT = null;
+
     protected $casts = [
         'date' => 'datetime',
     ];


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

# Description

I installed laravel nova and had the problem that nearly of the metrics are based on the created at coliumn since it is the default of the constant. Even though it is removed with `$timestamps = false;`

## Does this close any currently open issues?

Fixes #
No

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->

No

## Any other comments?

No

# Checklist

- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
