### PR TITLE
Configurable user model & new aggregate value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ No breaking changes. The only changes are to the development dependencies used f
 
 ## Changes
 
+- Add second-level aggregation and make sure that microseconds is always set to 0
+
 ### 3.2.0 - 2024-02-28
 
 - Add Laravel 11 compatibility

--- a/config/route-statistics.php
+++ b/config/route-statistics.php
@@ -46,15 +46,4 @@ return [
     |
     */
     'queued' => env('ROUTE_STATISTICS_QUEUED', false),
-
-    /*
-    |--------------------------------------------------------------------------
-    | User Model
-    |--------------------------------------------------------------------------
-    |
-    | This is the model used for user relationships.
-    | You can set a custom user model for relationships.
-    |
-    */
-    'user_model' => env('ROUTE_STATISTICS_USER_MODEL', config('auth.providers.users.model')),
 ];

--- a/config/route-statistics.php
+++ b/config/route-statistics.php
@@ -18,7 +18,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | This setting controls how we should aggregate requests.
-    | Possible values are: MINUTE, HOUR, DAY, MONTH, YEAR
+    | Possible values are: SECOND, MINUTE, HOUR, DAY, MONTH, YEAR
     |
     */
     'aggregate' => env('ROUTE_STATISTICS_AGGREGATE', 'DAY'),
@@ -46,4 +46,15 @@ return [
     |
     */
     'queued' => env('ROUTE_STATISTICS_QUEUED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the model used for user relationships.
+    | You can set a custom user model for relationships.
+    |
+    */
+    'user_model' => env('ROUTE_STATISTICS_USER_MODEL', config('auth.providers.users.model')),
 ];

--- a/src/Models/RouteStatistic.php
+++ b/src/Models/RouteStatistic.php
@@ -53,7 +53,7 @@ class RouteStatistic extends Model implements RequestLoggerInterface
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo(config('route-statistics.user_model'));
+        return $this->belongsTo(config('auth.providers.users.model'));
     }
 
     public function team(): BelongsTo

--- a/src/Models/RouteStatistic.php
+++ b/src/Models/RouteStatistic.php
@@ -53,7 +53,7 @@ class RouteStatistic extends Model implements RequestLoggerInterface
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo(config('auth.providers.users.model'));
+        return $this->belongsTo(config('route-statistics.user_model'));
     }
 
     public function team(): BelongsTo
@@ -109,8 +109,12 @@ class RouteStatistic extends Model implements RequestLoggerInterface
         $date = Date::now();
         $aggregate = config('route-statistics.aggregate');
 
-        if ($aggregate && ! in_array($aggregate, ['YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE'])) {
+        if ($aggregate && ! in_array($aggregate, ['YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND'])) {
             throw new \OutOfBoundsException('Invalid date aggregation');
+        }
+
+        if (in_array($aggregate, ['YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND'])) {
+            $date->setMicrosecond(0);
         }
 
         if (in_array($aggregate, ['YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE'])) {


### PR DESCRIPTION
# Description

Making user model configurable and add SECOND aggregate to set microsecond to 0.

## Does this close any currently open issues?

No. But the configurable model is needed to make code compatible with LdapRecord. LdapRecord, when using database configuration, the user relation is from auth.providers.users.**database**.model and not from auth.providers.users.model. Therefore, both packages won't work together. As of now, a custom model is required.

The aggregate is needed for MSSQL. Currently, once date is inserted, the datetime value still accepting time other than 0.

Before aggregate: 2024-04-29 00:00:00.**950**
After aggregate: 2024-04-30 00:00:00.**000**