### PR TITLE
Order migrations by the second to avoid migration conflicts

### DIFF
--- a/src/LaravelRouteStatisticsServiceProvider.php
+++ b/src/LaravelRouteStatisticsServiceProvider.php
@@ -59,8 +59,8 @@ class LaravelRouteStatisticsServiceProvider extends ServiceProvider
     private function publishMigrations()
     {
         $this->publishes([
-            __DIR__.'/../database/migrations/create_route_statistics_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_route_statistics_table.php'),
-            __DIR__.'/../database/migrations/add_parameters_to_route_statistics_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_add_parameters_to_route_statistics_table.php'),
+            __DIR__.'/../database/migrations/create_route_statistics_table.php.stub' => database_path('migrations/'.date('Y_m_d_Hi', time()).'00_create_route_statistics_table.php'),
+            __DIR__.'/../database/migrations/add_parameters_to_route_statistics_table.php.stub' => database_path('migrations/'.date('Y_m_d_Hi', time()).'01_add_parameters_to_route_statistics_table.php'),
             // you can add any number of migrations here
         ], 'migrations');
     }


### PR DESCRIPTION
# Description

This PR changes how migrations are published by ordering them by the current time's second. While not the ideal fix this does provide backwards safety as it only effects new installs.

## Does this close any currently open issues?

Fixes #46 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Any relevant logs, error output, etc?

nope

...

## Any other comments?

nope

...

# Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
