### PR TITLE
Faker did not allow json() anymore, fix factory

### DIFF
--- a/database/factories/RouteStatisticFactory.php
+++ b/database/factories/RouteStatisticFactory.php
@@ -15,7 +15,7 @@ class RouteStatisticFactory extends Factory
             'method' => $this->faker->randomElement(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
             'route' => $this->faker->domainWord().'.'.$this->faker->randomElement(['index', 'create', 'store', 'show', 'edit', 'update', 'destroy']),
             'status' => $this->faker->randomElement([200, 201, 202, 204, 300, 301, 302, 303, 304, 400, 401, 402, 403, 404, 405, 406, 422, 429, 500, 501, 502, 503, 504]),
-            'parameters' => $this->faker->json(),
+            'parameters' => json_encode($this->faker->sentence(4)),
             'ip' => $this->faker->ipv4(),
             'date' => $this->faker->dateTime(),
             'counter' => $this->faker->randomNumber(4),

--- a/tests/Unit/RouteStatisticModelTest.php
+++ b/tests/Unit/RouteStatisticModelTest.php
@@ -89,7 +89,7 @@ class RouteStatisticModelTest extends TestCase
         $model = RouteStatistic::factory()->make();
 
         $this->assertInstanceOf(RouteStatistic::class, $model);
-        $this->assertEquals($model->attributes['parameters'], json_encode($model->parameters));
+        $this->assertEquals($model->getAttributes()['parameters'], json_encode($model->parameters));
     }
 
     private function get_route_parameters(array $parameters): array

--- a/tests/Unit/RouteStatisticModelTest.php
+++ b/tests/Unit/RouteStatisticModelTest.php
@@ -85,7 +85,8 @@ class RouteStatisticModelTest extends TestCase
         $this->assertNull($log->parameters);
     }
 
-    public function test_can_create_instance_from_factory(): void {
+    public function test_can_make_instance_from_factory(): void
+    {
         $model = RouteStatistic::factory()->make();
 
         $this->assertInstanceOf(RouteStatistic::class, $model);

--- a/tests/Unit/RouteStatisticModelTest.php
+++ b/tests/Unit/RouteStatisticModelTest.php
@@ -85,6 +85,13 @@ class RouteStatisticModelTest extends TestCase
         $this->assertNull($log->parameters);
     }
 
+    public function test_can_create_instance_from_factory(): void {
+        $model = RouteStatistic::factory()->make();
+
+        $this->assertInstanceOf(RouteStatistic::class, $model);
+        $this->assertEquals($model->attributes['parameters'], json_encode($model->parameters));
+    }
+
     private function get_route_parameters(array $parameters): array
     {
         return array_values($parameters);


### PR DESCRIPTION
# Description

`json()` is not available on faker anymore, so we need to construct a json string our self
