### PR TITLE
Factory failed because of missing json function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-route-statistics` will be documented in this fil
 
 ## Changes
 
+### 4.2.1 - 2025-04-09
+
+- Fix json generation in RouteStatisticFactory
+
 ### 4.2.0 - 2025-02-17
 
 - Add Laravel 12 support

--- a/database/factories/RouteStatisticFactory.php
+++ b/database/factories/RouteStatisticFactory.php
@@ -15,7 +15,7 @@ class RouteStatisticFactory extends Factory
             'method' => $this->faker->randomElement(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
             'route' => $this->faker->domainWord().'.'.$this->faker->randomElement(['index', 'create', 'store', 'show', 'edit', 'update', 'destroy']),
             'status' => $this->faker->randomElement([200, 201, 202, 204, 300, 301, 302, 303, 304, 400, 401, 402, 403, 404, 405, 406, 422, 429, 500, 501, 502, 503, 504]),
-            'parameters' => $this->faker->json(),
+            'parameters' => json_encode($this->faker->sentence(4)),
             'ip' => $this->faker->ipv4(),
             'date' => $this->faker->dateTime(),
             'counter' => $this->faker->randomNumber(4),

--- a/tests/Unit/RouteStatisticModelTest.php
+++ b/tests/Unit/RouteStatisticModelTest.php
@@ -89,7 +89,7 @@ class RouteStatisticModelTest extends TestCase
         $model = RouteStatistic::factory()->make();
 
         $this->assertInstanceOf(RouteStatistic::class, $model);
-        $this->assertEquals($model->attributes['parameters'], json_encode($model->parameters));
+        $this->assertEquals($model->getAttributes()['parameters'], json_encode($model->parameters));
     }
 
     private function get_route_parameters(array $parameters): array

--- a/tests/Unit/RouteStatisticModelTest.php
+++ b/tests/Unit/RouteStatisticModelTest.php
@@ -85,7 +85,8 @@ class RouteStatisticModelTest extends TestCase
         $this->assertNull($log->parameters);
     }
 
-    public function test_can_create_instance_from_factory(): void {
+    public function test_can_make_instance_from_factory(): void
+    {
         $model = RouteStatistic::factory()->make();
 
         $this->assertInstanceOf(RouteStatistic::class, $model);

--- a/tests/Unit/RouteStatisticModelTest.php
+++ b/tests/Unit/RouteStatisticModelTest.php
@@ -85,6 +85,13 @@ class RouteStatisticModelTest extends TestCase
         $this->assertNull($log->parameters);
     }
 
+    public function test_can_create_instance_from_factory(): void {
+        $model = RouteStatistic::factory()->make();
+
+        $this->assertInstanceOf(RouteStatistic::class, $model);
+        $this->assertEquals($model->attributes['parameters'], json_encode($model->parameters));
+    }
+
     private function get_route_parameters(array $parameters): array
     {
         return array_values($parameters);


### PR DESCRIPTION
Faker didn’t support `json()` anymore. We need to create a fake json our self now.

Because there is no complex thing going on, it might be good enough to create a random array `fake()->sentece(3)` and `json_encode()` our self.

This PR solves this issue.

Reopen #51 , because of some internal github issue.